### PR TITLE
Flush only the dirty range on set_executable()

### DIFF
--- a/monoasm/examples/icache_bench.rs
+++ b/monoasm/examples/icache_bench.rs
@@ -1,0 +1,28 @@
+//! Synthetic reproduction of the monoruby workload: many small
+//! `finalize()` calls against a code region that keeps growing.
+//!
+//! Run with `cargo run --release --example icache_bench` (AArch64 shows the
+//! real cache-maintenance cost; on x86-64 the flush is a no-op).
+use monoasm::*;
+
+fn main() {
+    let rounds: usize = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20_000);
+    let mut jit = JitMemory::new();
+    let start = std::time::Instant::now();
+    for _ in 0..rounds {
+        for _ in 0..16 {
+            jit.emitl(0xd503_201f); // nop
+        }
+        jit.finalize();
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "{} finalize() calls, {} bytes of code: {:?}",
+        rounds,
+        jit.get_current(),
+        elapsed
+    );
+}

--- a/monoasm/src/jit_memory.rs
+++ b/monoasm/src/jit_memory.rs
@@ -61,6 +61,12 @@ pub struct MemPage {
     code_block_top: Pos,
     /// Code blocks. (start_pos, code_end, end_pos)
     pub code_block: Vec<(Pos, Pos, Pos)>,
+    /// Low watermark of the byte range written since the last
+    /// `set_executable()`. See [`MemPage::mark_dirty_pos`].
+    dirty_lo: usize,
+    /// High watermark (exclusive) of the byte range written since the last
+    /// `set_executable()`. The range is empty iff `dirty_lo >= dirty_hi`.
+    dirty_hi: usize,
 }
 
 impl Index<Pos> for MemPage {
@@ -79,6 +85,11 @@ impl IndexMut<Pos> for MemPage {
         if index.0 >= PAGE_SIZE {
             panic!("Page size overflow")
         }
+        // Single byte-level chokepoint for every write into this page
+        // (`emit*`, `write32`/`write64`, and direct `page[pos] = b`), so
+        // recording the watermark here is enough to make `set_executable`
+        // flush exactly what was touched.
+        self.mark_dirty_pos(index.0, 1);
         unsafe { &mut *self.contents().add(index.0) }
     }
 }
@@ -93,11 +104,39 @@ impl MemPage {
             code_len: 0usize,
             code_block_top: Pos(0),
             code_block: vec![],
+            dirty_lo: usize::MAX,
+            dirty_hi: 0,
         }
     }
 
     pub(crate) fn contents(&self) -> *mut u8 {
         self.contents as *mut u8
+    }
+
+    /// Widen the dirty watermark to cover `[pos, pos + len)`.
+    ///
+    /// The watermark bounds everything written into this page since the
+    /// last [`JitMemory::set_executable`], and is what gets handed to
+    /// `invalidate_icache`. Keep this branch-free: it runs once per byte
+    /// written on the emit hot path.
+    #[inline]
+    pub(crate) fn mark_dirty_pos(&mut self, pos: usize, len: usize) {
+        self.dirty_lo = self.dirty_lo.min(pos);
+        self.dirty_hi = self.dirty_hi.max(pos + len);
+    }
+
+    /// The byte range written since the last `set_executable()`, or `None`
+    /// if nothing was written.
+    #[inline]
+    fn take_dirty(&mut self) -> Option<(usize, usize)> {
+        let (lo, hi) = (self.dirty_lo, self.dirty_hi);
+        self.dirty_lo = usize::MAX;
+        self.dirty_hi = 0;
+        if lo < hi {
+            Some((lo, hi))
+        } else {
+            None
+        }
     }
 
     /// Adjust cursor with 4KB alignment.
@@ -237,7 +276,9 @@ impl IndexMut<Pos> for JitMemory {
         // state so callers (incl. MemPage's emit helpers via deref)
         // don't fault on Apple Silicon.
         self.ensure_writable();
-        unsafe { &mut *self.contents().add(index.0) }
+        let page = self.page;
+        self.pages[page.0].mark_dirty_pos(index.0, 1);
+        unsafe { &mut *self.pages[page.0].contents().add(index.0) }
     }
 }
 
@@ -295,12 +336,46 @@ impl JitMemory {
     /// [`finalize`](Self::finalize).
     pub fn set_executable(&mut self) {
         self.protect.set_executable();
-        // Synchronize the I-cache over the freshly written code so the
-        // CPU sees the new instructions (a no-op on x86-64).
-        for page in &self.pages[..2] {
-            let len = page.code_len.max(page.counter.0);
-            if len > 0 {
-                unsafe { JitProtect::invalidate_icache(page.contents(), len) }
+        // Synchronize the I-cache over the bytes actually written since the
+        // previous `set_executable()` (a no-op on x86-64).
+        //
+        // Flushing each page in full instead would cost O(total code
+        // emitted so far) per call, i.e. O(N^2) over a process that
+        // finalizes N times — which is exactly what made repeated JIT
+        // compilation crawl on Apple Silicon, where `sys_icache_invalidate`
+        // costs time proportional to the range.
+        for (id, page) in self.pages.iter_mut().enumerate() {
+            // Every page's watermark is reset, but only the code pages get
+            // cache maintenance — the data page is never executed.
+            let dirty = page.take_dirty();
+            if id < DATA_PAGE.0 {
+                if let Some((lo, hi)) = dirty {
+                    unsafe { JitProtect::invalidate_icache(page.contents().add(lo), hi - lo) }
+                }
+            }
+        }
+    }
+
+    /// Record that `len` bytes at `ptr` were written into the JIT region
+    /// through a raw pointer, bypassing the [`MemPage`] write helpers.
+    ///
+    /// Writes that go through `emit*`, `write32`/`write64` or `page[pos]`
+    /// mark themselves; this is the escape hatch for code that patches
+    /// already-emitted instructions via an address obtained from
+    /// [`get_label_address`](Self::get_label_address) or
+    /// [`get_current_address`](Self::get_current_address). Without it the
+    /// patch would not be part of the range handed to `invalidate_icache`
+    /// by the next [`set_executable`](Self::set_executable), and an
+    /// AArch64 core could keep executing the stale instruction.
+    ///
+    /// A `ptr` outside the JIT pages is ignored.
+    pub fn mark_dirty(&mut self, ptr: *const u8, len: usize) {
+        let p = ptr as usize;
+        for page in &mut self.pages {
+            let base = page.contents() as usize;
+            if p >= base && p - base < PAGE_SIZE {
+                page.mark_dirty_pos(p - base, len);
+                return;
             }
         }
     }
@@ -595,5 +670,107 @@ impl JitMemory {
     /// Emit bytes.
     pub fn emit(&mut self, slice: &[u8]) {
         slice.iter().for_each(|b| self.emitb(*b));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dirty(jit: &JitMemory, page: Page) -> Option<(usize, usize)> {
+        let page = &jit.pages[page.0];
+        if page.dirty_lo < page.dirty_hi {
+            Some((page.dirty_lo, page.dirty_hi))
+        } else {
+            None
+        }
+    }
+
+    /// The whole point of the watermark: consecutive publishes must flush
+    /// only what each one wrote, not the page from its start.
+    #[test]
+    fn dirty_range_covers_only_the_new_writes() {
+        let mut jit = JitMemory::new();
+        assert_eq!(None, dirty(&jit, Page(0)));
+
+        jit.emitl(0xdead_beef);
+        assert_eq!(Some((0, 4)), dirty(&jit, Page(0)));
+
+        jit.set_executable();
+        assert_eq!(None, dirty(&jit, Page(0)));
+
+        jit.emitl(0x1234_5678);
+        assert_eq!(Some((4, 8)), dirty(&jit, Page(0)));
+
+        jit.set_executable();
+        // A publish with nothing written in between flushes nothing.
+        jit.set_executable();
+        assert_eq!(None, dirty(&jit, Page(0)));
+    }
+
+    /// Patching already-published code (late label binds, stub / inline
+    /// cache updates) must re-dirty the patched bytes — this is the case a
+    /// naive "flush the current code block" scheme would miss.
+    #[test]
+    fn patching_published_code_re_dirties_it() {
+        let mut jit = JitMemory::new();
+        for _ in 0..64 {
+            jit.emitb(0);
+        }
+        jit.set_executable();
+        assert_eq!(None, dirty(&jit, Page(0)));
+
+        jit[Page(0)].write32(Pos(16), 0x0011_2233);
+        assert_eq!(Some((16, 20)), dirty(&jit, Page(0)));
+
+        jit.set_executable();
+        jit[Page(0)].write64(Pos(40), 0);
+        assert_eq!(Some((40, 48)), dirty(&jit, Page(0)));
+    }
+
+    /// Each page keeps its own range, so touching one doesn't make the
+    /// other pay for it.
+    #[test]
+    fn dirty_ranges_are_per_page() {
+        let mut jit = JitMemory::new();
+        jit.select_page(1);
+        jit.emitl(0);
+        assert_eq!(None, dirty(&jit, Page(0)));
+        assert_eq!(Some((0, 4)), dirty(&jit, Page(1)));
+
+        jit.set_executable();
+        assert_eq!(None, dirty(&jit, Page(1)));
+    }
+
+    /// `mark_dirty` is the escape hatch for raw-pointer patches; it has to
+    /// resolve the address to the right page, and ignore foreign pointers.
+    #[test]
+    fn mark_dirty_resolves_addresses_to_pages() {
+        let mut jit = JitMemory::new();
+        jit.set_executable();
+
+        let p0 = unsafe { jit[Page(0)].contents().add(8) };
+        let p1 = unsafe { jit[Page(1)].contents().add(32) };
+        jit.mark_dirty(p0, 4);
+        jit.mark_dirty(p1, 4);
+        assert_eq!(Some((8, 12)), dirty(&jit, Page(0)));
+        assert_eq!(Some((32, 36)), dirty(&jit, Page(1)));
+
+        jit.set_executable();
+        let outside = &0u8 as *const u8;
+        jit.mark_dirty(outside, 1);
+        assert_eq!(None, dirty(&jit, Page(0)));
+        assert_eq!(None, dirty(&jit, Page(1)));
+    }
+
+    /// The data page is never executed, but its watermark must still be
+    /// reset so it doesn't grow unboundedly across finalizes.
+    #[test]
+    fn data_page_watermark_is_reset() {
+        let mut jit = JitMemory::new();
+        jit[DATA_PAGE].emitq(0);
+        assert_eq!(Some((0, 8)), dirty(&jit, DATA_PAGE));
+        jit.set_executable();
+        assert_eq!(None, dirty(&jit, DATA_PAGE));
     }
 }

--- a/monoasm/src/jit_memory.rs
+++ b/monoasm/src/jit_memory.rs
@@ -35,6 +35,10 @@ pub struct JitMemory {
     /// per-thread writability tracking on macOS/aarch64 and is a
     /// zero-sized no-op on x86-64.
     protect: JitProtect,
+    /// Set by an explicit [`JitMemory::set_writable`], which announces a
+    /// write monoasm cannot track. Makes the next `set_executable()` flush
+    /// the whole code region instead of the dirty range.
+    flush_all: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -308,6 +312,7 @@ impl JitMemory {
             pages: [initial_page, second_page, data_page],
             labels: vec![],
             protect,
+            flush_all: false,
         }
     }
 
@@ -326,7 +331,16 @@ impl JitMemory {
     /// On macOS/AArch64 this calls `pthread_jit_write_protect_np(0)`;
     /// elsewhere it is a no-op. Callers don't normally need this — every
     /// emit path lazily flips back to writable via `ensure_writable`.
+    ///
+    /// Calling this explicitly means the caller is about to write into the
+    /// JIT region behind monoasm's back, so it also arms a conservative
+    /// full-region I-cache flush at the next
+    /// [`set_executable`](Self::set_executable): monoasm cannot see where
+    /// such a raw write landed. Use [`mark_dirty`](Self::mark_dirty)
+    /// instead to make the region writable *and* declare the patched range,
+    /// which keeps the flush proportional to the patch.
     pub fn set_writable(&mut self) {
+        self.flush_all = true;
         self.protect.set_writable();
     }
 
@@ -344,32 +358,48 @@ impl JitMemory {
         // finalizes N times — which is exactly what made repeated JIT
         // compilation crawl on Apple Silicon, where `sys_icache_invalidate`
         // costs time proportional to the range.
+        let flush_all = std::mem::replace(&mut self.flush_all, false);
         for (id, page) in self.pages.iter_mut().enumerate() {
             // Every page's watermark is reset, but only the code pages get
             // cache maintenance — the data page is never executed.
-            let dirty = page.take_dirty();
+            let dirty = if flush_all {
+                // An explicit `set_writable()` may have been followed by a
+                // raw write monoasm never saw; fall back to the whole
+                // written extent of the page.
+                page.take_dirty();
+                Some((0, page.code_len.max(page.counter.0)))
+            } else {
+                page.take_dirty()
+            };
             if id < DATA_PAGE.0 {
                 if let Some((lo, hi)) = dirty {
-                    unsafe { JitProtect::invalidate_icache(page.contents().add(lo), hi - lo) }
+                    if lo < hi {
+                        unsafe { JitProtect::invalidate_icache(page.contents().add(lo), hi - lo) }
+                    }
                 }
             }
         }
     }
 
-    /// Record that `len` bytes at `ptr` were written into the JIT region
-    /// through a raw pointer, bypassing the [`MemPage`] write helpers.
+    /// Declare an out-of-band write of `len` bytes at `ptr`: make the JIT
+    /// region writable for the current thread and record the range so the
+    /// next [`set_executable`](Self::set_executable) synchronizes the
+    /// I-cache over it.
     ///
     /// Writes that go through `emit*`, `write32`/`write64` or `page[pos]`
-    /// mark themselves; this is the escape hatch for code that patches
-    /// already-emitted instructions via an address obtained from
+    /// record themselves; this is for code that patches already-emitted
+    /// instructions through a raw pointer obtained from
     /// [`get_label_address`](Self::get_label_address) or
-    /// [`get_current_address`](Self::get_current_address). Without it the
-    /// patch would not be part of the range handed to `invalidate_icache`
-    /// by the next [`set_executable`](Self::set_executable), and an
-    /// AArch64 core could keep executing the stale instruction.
+    /// [`get_current_address`](Self::get_current_address). Call it *before*
+    /// the write, in place of [`set_writable`](Self::set_writable) — that
+    /// one has to fall back to flushing the whole code region, since it
+    /// says nothing about where the write will land. Skipping both leaves
+    /// the patch out of the flushed range, and an AArch64 core can keep
+    /// executing the stale instruction.
     ///
     /// A `ptr` outside the JIT pages is ignored.
     pub fn mark_dirty(&mut self, ptr: *const u8, len: usize) {
+        self.ensure_writable();
         let p = ptr as usize;
         for page in &mut self.pages {
             let base = page.contents() as usize;
@@ -761,6 +791,32 @@ mod tests {
         jit.mark_dirty(outside, 1);
         assert_eq!(None, dirty(&jit, Page(0)));
         assert_eq!(None, dirty(&jit, Page(1)));
+    }
+
+    /// An explicit `set_writable()` announces a write monoasm can't see, so
+    /// the next publish must fall back to the whole code region — that is
+    /// what pre-existing "make writable, patch raw, make executable"
+    /// callers rely on.
+    #[test]
+    fn explicit_set_writable_forces_a_full_flush() {
+        let mut jit = JitMemory::new();
+        for _ in 0..64 {
+            jit.emitb(0);
+        }
+        jit.finalize();
+        assert!(!jit.flush_all);
+
+        jit.set_writable();
+        assert!(jit.flush_all);
+        // No tracked write at all, yet the whole written extent must still
+        // be considered dirty.
+        assert_eq!(None, dirty(&jit, Page(0)));
+        jit.set_executable();
+        assert!(!jit.flush_all);
+
+        // …and it is one-shot: the next publish is incremental again.
+        jit.emitb(0);
+        assert_eq!(Some((64, 65)), dirty(&jit, Page(0)));
     }
 
     /// The data page is never executed, but its watermark must still be

--- a/monoasm/src/x64.rs
+++ b/monoasm/src/x64.rs
@@ -544,10 +544,10 @@ impl JitMemory {
     pub fn apply_jmp_patch_address(&mut self, patch_point: CodePtr, jmp_dest: &DestLabel) {
         let jmp_dest = self.get_label_address(jmp_dest);
         let offset = jmp_dest - patch_point - 5;
-        unsafe { *(patch_point.as_ptr().add(1) as *mut [u8; 4]) = (offset as i32).to_ne_bytes() };
-        // Raw-pointer write: register it so the next `set_executable()`
+        // Raw-pointer write: declare it so the next `set_executable()`
         // covers the patched displacement.
         self.mark_dirty(unsafe { patch_point.as_ptr().add(1) }, 4);
+        unsafe { *(patch_point.as_ptr().add(1) as *mut [u8; 4]) = (offset as i32).to_ne_bytes() };
     }
 
     /// Dump generated code.

--- a/monoasm/src/x64.rs
+++ b/monoasm/src/x64.rs
@@ -545,6 +545,9 @@ impl JitMemory {
         let jmp_dest = self.get_label_address(jmp_dest);
         let offset = jmp_dest - patch_point - 5;
         unsafe { *(patch_point.as_ptr().add(1) as *mut [u8; 4]) = (offset as i32).to_ne_bytes() };
+        // Raw-pointer write: register it so the next `set_executable()`
+        // covers the patched displacement.
+        self.mark_dirty(unsafe { patch_point.as_ptr().add(1) }, 4);
     }
 
     /// Dump generated code.


### PR DESCRIPTION
## Background

`set_executable()` handed `invalidate_icache` the whole of each code page from offset 0, using `code_len.max(counter)` as the length. Since `finalize()` calls it after every JIT compilation, the Nth finalize paid O(total code emitted so far), making a long-lived process **O(N²)** in cache maintenance.

x86-64 never noticed — `invalidate_icache` is a no-op there — but on AArch64 the cost is proportional to the range: `sys_icache_invalidate` on macOS, and the `dc cvau` / `ic ivau` line walk elsewhere. In monoruby's test suite, one test doing 60 VM boots issues ~202,000 `finalize()` calls against a code region that grows to ~19.6 MB, pushing ~2 TB through `sys_icache_invalidate` (294s on darwin vs 10s on amd64).

## Changes

### 1. Flush only the dirty range (`3a76b0d`)

Each page now carries a `[dirty_lo, dirty_hi)` watermark of the bytes written since the previous `set_executable()`, and only that range is flushed.

The watermark is updated in `MemPage`'s `IndexMut<Pos>` — the single byte-level chokepoint that `emit*`, `write32`/`write64` and `page[pos] = b` all funnel through. That matters: a naive "flush the current code block" scheme would miss **late writes into already-published code** (relocations resolved by a later `bind_label`, stub and inline-cache patches), and those are covered here.

The W^X toggling and the barrier sequences (`pthread_jit_write_protect_np`, the `dc`/`ic`/`dsb`/`isb` ordering) are unchanged. **Only the flushed range is different.**

### 2. Keep raw-pointer patchers correct (`c5745b1`)

Callers that patch already-published instructions through a raw pointer do it as `set_writable()` → write → `set_executable()`, relying on the old full-page flush; monoruby's aarch64 `patch_return_to_deopt` / `patch_call_to_entry` are exactly that. With only the dirty range flushed, such a patch would be published without any cache maintenance and an AArch64 core could keep running the stale instruction. So:

- An explicit `set_writable()` is treated as the signal that a write monoasm cannot see is coming, and arms a **one-shot full-region flush** at the next `set_executable()`. Internal emit paths use `ensure_writable()`, not `set_writable()`, so `finalize()` stays on the incremental path.
- **`JitMemory::mark_dirty(ptr, len)`** is the precise alternative. It also makes the region writable, so it can replace `set_writable()` at those patch sites and keep the flush proportional to the patch. `apply_jmp_patch_address` now uses it.

Existing callers stay correct with no changes on their side.

## Measurements

`monoasm/examples/icache_bench` (20,000 `finalize()` calls over 1.28 MB of code):

| | before | after |
|---|---|---|
| aarch64 (qemu-user, `dc`/`ic` walk) | 26.19 s | 29.7 ms |
| x86-64 (flush is a no-op) | ~3.8 ms | ~4.7 ms |

The x86-64 delta is the watermark bookkeeping itself, ~0.7 ns per emitted byte. On the monoruby workload above (~19.6 MB) that is ~15 ms total against a 10 s baseline, so the byte-level chokepoint is kept for safety rather than marking at the coarser emit helpers.

## Testing

- **x86-64**: 25 integration tests + 6 new unit tests, all passing.
- **aarch64** (cross-build + qemu-user): 43 integration tests + 6 new unit tests, all passing.
- The new unit tests pin down:
  - consecutive publishes flush only what each one wrote, and a publish with nothing written in between flushes nothing
  - patching published code (`write32` / `write64`) re-dirties it
  - dirty ranges are per-page
  - `mark_dirty` resolves addresses to the right page and ignores foreign pointers
  - an explicit `set_writable()` forces exactly one full flush
- No new clippy or rustfmt findings (the two existing clippy hits and the fmt diff at `x64.rs:662` predate this branch).

## Notes

- Branched from `aarch` (rev `13bc64a`).
- monoruby integration: builds succeed on both x86-64 and aarch64. The test run was not completed here because this environment has CRuby 3.3.6, which produces Ruby-version-dependent failures unrelated to this change (`Array#fetch_values` and `Array#rfind` do not exist, `(0...2**64).max(2)` does not terminate, Ruby 3.4 changed `Hash#inspect` formatting). **Verification on another environment is requested.**
- The darwin before/after (expected 294s → ~10s) has not been measured.
- qemu-user detects self-modifying code and invalidates its translation blocks, so its ability to catch a missed I-cache flush is limited. The qemu run mainly serves as code-path regression coverage; verification on real aarch64 / darwin is still needed.